### PR TITLE
Page ui

### DIFF
--- a/src/app/(container)/container/page.tsx
+++ b/src/app/(container)/container/page.tsx
@@ -1,12 +1,40 @@
 'use client';
 
-import HostCard from '@/components/card/hostCard';
+import React from 'react';
+import { CardContainer, ConnectBar, HostCard } from '@/components';
 
-const ContainerPage = () => {
+type Container = {
+  name: string;
+  ip: string;
+  status: 'running' | 'stopped';
+};
+
+type Network = {
+  networkIp: string;
+  containers: Container[];
+};
+
+type Host = {
+  hostNm?: string;
+  ip: string;
+  status?: boolean;
+};
+
+type CardProps = {
+  host: Host;
+  network: Network;
+};
+
+const ContainerPage = ({ host, network }: CardProps) => {
   return (
-    <>
-      <HostCard ip="12.34.56.67" />
-    </>
+    <div className="flex space-x-0">
+      <HostCard hostNm={host.hostNm} ip={host.ip} status={host.status} />
+      <ConnectBar />
+      <CardContainer
+        networkIp={network.networkIp}
+        containers={network.containers}
+      />
+    </div>
   );
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,24 @@
-import Image from 'next/image';
 import React from 'react';
 import ImagePage from './(image)/image/page';
+import ContainerPage from './(container)/container/page';
+import { HOST_DATA, NETWORK_DATA } from '@/data/mock';
+
+type Container = {
+  name: string;
+  ip: string;
+  status: 'running' | 'stopped';
+};
+
+export type Network = {
+  networkIp: string;
+  containers: Container[];
+};
 
 export default function Page() {
   return (
     <div>
       <ImagePage />
+      <ContainerPage host={HOST_DATA} network={NETWORK_DATA} />
     </div>
   );
 }

--- a/src/components/bar/connectBar.tsx
+++ b/src/components/bar/connectBar.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const ConnectBar = () => {
+  return (
+    <div className="flex items-start mt-5">
+      <div className="h-6 bg-blue_2 rounded-br rounded-tr w-1" />
+      <div className="w-6 h-[1px] bg-blue_2 mt-3" />
+    </div>
+  );
+};
+
+export default ConnectBar;

--- a/src/components/bar/progressBar.tsx
+++ b/src/components/bar/progressBar.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface ProgressBarProps {
+  progress: number;
+}
+
+const ProgressBar = ({ progress }: ProgressBarProps) => {
+  return (
+    // <div className="mb-1">
+    //   <div className="flex justify-between items-center mb-1">
+    //     <span className="text-base font-semibold">{progress}%</span>
+    //   </div>
+    //   <div className="w-full bg-grey_1 rounded-full h-3">
+    //     <div
+    //       className="bg-grey_6 h-3 rounded-full"
+    //       style={{ width: `${progress}%` }}
+    //     />
+    //   </div>
+    // </div>
+    <div className="mb-1 mt-4 relative">
+      {/* 디자인 제안! */}
+      <div className="w-full bg-grey_1 rounded-full h-4">
+        <div
+          className="bg-grey_6 h-4 rounded-full"
+          style={{ width: `${progress}%` }}
+        ></div>
+        <div className="absolute inset-0 flex justify-center items-center">
+          <span className="text-base font-semibold">{progress}%</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProgressBar;

--- a/src/components/card/cardContainer.tsx
+++ b/src/components/card/cardContainer.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+type Container = {
+  name: string;
+  ip: string;
+  status: 'running' | 'stopped';
+};
+
+type CardContainerkProps = {
+  networkIp: string;
+  containers: Container[];
+};
+
+const CardContainer = ({ networkIp, containers }: CardContainerkProps) => {
+  return (
+    <div className="flex flex-col items-center p-[10px] border bg-white border-grey_3 rounded-lg shadow-lg w-[450px]">
+      <div className="w-full text-center bg-blue_1 text-blue_2 border-2 border-blue_2 p-2 rounded-md mb-3 text-sm font-semibold">
+        {`docker0 : ${networkIp}`}
+      </div>
+      {containers.length > 0 ? (
+        <div className="w-full max-h-52 overflow-y-auto scrollbar-hide">
+          {containers.map((container, index) => (
+            <div
+              key={index}
+              className="flex justify-between items-center p-2 mb-2 border rounded-md bg-gray-50"
+            >
+              <span>{container.name}</span>
+              <div className="flex items-center space-x-4">
+                <span>{container.ip}</span>
+                <span
+                  className={`w-2 h-2 rounded-full ${
+                    container.status === 'running'
+                      ? 'bg-green-500'
+                      : 'bg-red-500'
+                  }`}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default CardContainer;

--- a/src/components/card/hostCard.tsx
+++ b/src/components/card/hostCard.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react';
 import { FaHome } from 'react-icons/fa';
 
 type HostCardProps = {
@@ -11,7 +10,7 @@ type HostCardProps = {
   status?: boolean;
 };
 
-const HostCard: FC<HostCardProps> = ({ hostNm, ip, status = true }) => {
+const HostCard = ({ hostNm, ip, status = true }: HostCardProps) => {
   const borderColor = status ? 'border-blue_2' : 'border-red_2';
   const bgColor = status ? 'bg-blue_1' : 'bg-red_1';
   const textColor = status ? 'text-blue_2' : 'text-red_2';
@@ -21,7 +20,7 @@ const HostCard: FC<HostCardProps> = ({ hostNm, ip, status = true }) => {
       <div
         className={`flex items-center justify-center w-full space-x-2 rounded-md border-solid border-2 ${borderColor} ${bgColor} py-2 mb-3`}
       >
-        <FaHome className={`w-6 h-6 ${textColor}`} />
+        <FaHome className={`w-4 h-4 ${textColor}`} />
         <div className={`text-sm font-semibold ${textColor}`}>
           {hostNm || 'HOST'}
         </div>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,10 @@ export { default as Layout } from './layout/layout';
 export { default as Header } from './layout/header';
 export { default as Sidebar } from './layout/sideBar';
 
+// bar
+export { default as ConnectBar } from './bar/connectBar';
+export { default as ProgressBar } from './bar/progressBar';
+
 // button
 export { default as Button } from './button/button';
 export { default as ZoomButtons } from './button/zoomButtons';
@@ -11,6 +15,7 @@ export { default as PanButtons } from './button/panButtons';
 // card
 export { default as Card } from './card/card';
 export { default as HostCard } from './card/hostCard';
+export { default as CardContainer } from './card/cardContainer';
 
 // modal
 export { default as Modal } from './modal/modal';

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -39,7 +39,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="relative flex h-screen bg-basic_1">
       <Header />
-      <Sidebar data={cardData} />
+      <Sidebar data={cardData} progress={30} />
       <div className="flex flex-col flex-1 ml-[300px] mt-[56px]">
         <div className="flex-1 overflow-y-auto bg-basic_1 p-4 bg-grey_0">
           <main className={`relative ${isHandMode ? 'hand-mode' : ''}`}>

--- a/src/components/layout/sideBar.tsx
+++ b/src/components/layout/sideBar.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Button, Card } from '@/components';
+import { Button, Card, ProgressBar } from '@/components';
 
 interface SidebarProps {
   data: any[];
+  progress: number;
 }
 
-const Sidebar = ({ data }: SidebarProps) => {
+const Sidebar = ({ data, progress }: SidebarProps) => {
   return (
     <div className="fixed top-0 left-0 w-[300px] h-full flex flex-col bg-white p-4 border-r-2 border-grey_2 pt-20">
       <div className="flex-grow overflow-y-auto scrollbar-hide">
@@ -20,6 +21,7 @@ const Sidebar = ({ data }: SidebarProps) => {
         ))}
       </div>
       <div className="flex-shrink-0">
+        <ProgressBar progress={progress} />
         <Button title={'추가하기'} />
       </div>
     </div>

--- a/src/data/mock.ts
+++ b/src/data/mock.ts
@@ -1,15 +1,17 @@
+import { Network } from '@/app/page';
+
 export const IMAGE_CARD_DATA = [
   {
     id: 'sha-image',
     size: '124.2MB',
     tags: 'httpd/latest',
-    status: 'success',
+    status: 'primary',
   },
   {
     id: 'sha-24546wdjnas930m-gkdlxkduwldk',
     size: '35.2MB',
     tags: 'httpd/latest',
-    status: 'success',
+    status: 'secondary',
   },
   {
     id: 'suyoooi-24546wdjnas930m',
@@ -72,6 +74,26 @@ export const VOLUME_CARD_DATA = [
     id: 'sha-24546network930m-network',
     size: '35.2MB',
     tags: 'httpd/latest',
-    status: 'success',
+    status: 'primary',
   },
 ];
+
+export const HOST_DATA = {
+  hostNm: 'Host Name',
+  ip: '12.34.56.67',
+  status: true,
+};
+
+export const NETWORK_DATA: Network = {
+  networkIp: '172.17.0.1',
+  containers: [
+    { name: 'naver-backend', ip: '172.17.0.2', status: 'running' },
+    { name: 'naver-frontend', ip: '172.17.0.3', status: 'stopped' },
+    { name: 'naver-frontend', ip: '172.17.0.3', status: 'running' },
+    { name: 'naver-frontend', ip: '172.17.0.3', status: 'stopped' },
+    { name: 'naver-frontend', ip: '172.17.0.3', status: 'running' },
+    { name: 'naver-frontend', ip: '172.17.0.3', status: 'stopped' },
+    { name: 'naver-frontend', ip: '172.17.0.3', status: 'stopped' },
+    { name: 'naver-frontend', ip: '172.17.0.3', status: 'stopped' },
+  ],
+};


### PR DESCRIPTION
# 구현사항 [완료]  🍄



### components 🍥


### 1. cardContianer 🍋

- name/ip/status props으로 전달 
- status (running/stopped)에 따라 초록불/빨간불로 구분
- 일정 높이가 되면 스크롤로 확인 가능 (스크롤은 ui에 나타나지 않도록함)

![image](https://github.com/user-attachments/assets/ccc7e222-b027-49df-8684-926560fc2e37)


### 2. connectBar 🍬

- hostCard와 containerCard를 연결하는 컴포넌트
- 현재 길이 조절은 불가능함 (props으로 길이 전달 시 조절 가능)
- hostCard와 containerCard 사이에 넣으면 됨 (위치는 hostCard 상단에 고정되어 있음)
 
![image](https://github.com/user-attachments/assets/8547b20c-812a-4074-9c83-140a7f281f66)
![image](https://github.com/user-attachments/assets/be6f96f2-08b0-47de-89b7-3c163140dc01)

